### PR TITLE
Image handler comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/AddCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AddCommentServlet.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -38,34 +38,34 @@ public class AddCommentServlet extends HttpServlet {
     String email = userService.getCurrentUser().getEmail();
     String message = request.getParameter("message");
     long timestamp = System.currentTimeMillis();
-    String image = getUploadedFileUrl(request, "image");
+    Optional<String> image = getUploadedFileUrl(request);
 
     Entity newComment = new Entity("Comment");
 
     newComment.setProperty("email", email);
     newComment.setProperty("timestamp", timestamp);
     newComment.setProperty("message", message);
-    newComment.setProperty("image", image);
+    image.ifPresent(url -> newComment.setProperty("image", url));
 
     DatastoreServiceFactory.getDatastoreService().put(newComment);
   }
 
   /** Returns the URL to the uploaded file or null if the user didn't upload a file. */
-  private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+  private Optional<String> getUploadedFileUrl(HttpServletRequest request) {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     List<BlobKey> allCommentImageKeys = blobstoreService.getUploads(request).get("image");
 
     // User submitted form without selecting a file (on dev server)
-    if (allCommentImageKeys == null || allCommentImageKeys.isEmpty()) return null;
+    if (allCommentImageKeys == null || allCommentImageKeys.isEmpty()) return Optional.empty();
 
     // Since users can only upload one image per comment, get the first image
     BlobKey imageKey = allCommentImageKeys.get(0);
-
-    // User submitted form without selecting a file (on live server)
     BlobInfo imageInfo = new BlobInfoFactory().loadBlobInfo(imageKey);
+    
+    // User submitted form without selecting a file (on live server)
     if (imageInfo.getSize() == 0) {
       blobstoreService.delete(imageKey);
-      return null;
+      return Optional.empty();
     }
 
     // Use ImagesService to get a URL that points to the uploaded file.
@@ -76,9 +76,9 @@ public class AddCommentServlet extends HttpServlet {
     // the path returned by imagesService (which contains a host)
     try {
       URL url = new URL(imagesService.getServingUrl(options));
-      return url.getPath();
+      return Optional.ofNullable(url.getPath());
     } catch (MalformedURLException e) {
-      return imagesService.getServingUrl(options);
+      return Optional.ofNullable(imagesService.getServingUrl(options));
     }
   }
 }

--- a/portfolio/src/main/java/structures/Comment.java
+++ b/portfolio/src/main/java/structures/Comment.java
@@ -1,5 +1,7 @@
 package structures;
 
+import java.util.Optional;
+
 import com.google.appengine.api.datastore.Entity;
 
 public class Comment {
@@ -7,20 +9,19 @@ public class Comment {
   private long timestamp;
   private String message;
   private String email;
-  private String image;
+  private Optional<String> image;
 
   public Comment(Entity commentEntity) {
     this.id = commentEntity.getKey().getId();
     this.email = (String) commentEntity.getProperty("email");
     this.timestamp = (long) commentEntity.getProperty("timestamp");
     this.message = (String) commentEntity.getProperty("message");
-    this.image = commentEntity.getProperty("image") != null ? (String) commentEntity.getProperty("image") : null; 
+    this.image = Optional.ofNullable((String) commentEntity.getProperty("image"));
   }
 
   public long getId() { return id; }
   public String getEmail() { return email; }
   public long getTimestamp() { return timestamp; }
   public String getMessage() { return message; }
-
-  public void setMessage(String message) { this.message = message; }
+  public Optional<String> getImage() { return image; }
 }

--- a/portfolio/src/main/java/structures/Comment.java
+++ b/portfolio/src/main/java/structures/Comment.java
@@ -7,12 +7,14 @@ public class Comment {
   private long timestamp;
   private String message;
   private String email;
+  private String image;
 
   public Comment(Entity commentEntity) {
     this.id = commentEntity.getKey().getId();
     this.email = (String) commentEntity.getProperty("email");
     this.timestamp = (long) commentEntity.getProperty("timestamp");
     this.message = (String) commentEntity.getProperty("message");
+    this.image = commentEntity.getProperty("image") != null ? (String) commentEntity.getProperty("image") : null; 
   }
 
   public long getId() { return id; }


### PR DESCRIPTION
Edited the AddComment servlet to account for images with comments. If an image for the add comment request isn't found in blobstore, then the image was not uploaded and the image will be set to null in the comment object.