### PR TITLE
Optional attendee scheduling

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -28,12 +28,11 @@ public final class FindMeetingQuery {
     
     // Get the possible meeting times with and without the optional attendees.
     Collection<TimeRange> optionalTimes = getMeetingList(eventList, request, true);
-    Collection<TimeRange> requiredTimes = getMeetingList(eventList, request, false);
 
     if (optionalTimes.size() > 0) {
       return optionalTimes;
     } else if (request.getAttendees().size() > 0) {
-      return requiredTimes;
+      return getMeetingList(eventList, request, false);
     } else {
       return Arrays.asList();
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -26,6 +26,7 @@ public final class FindMeetingQuery {
     List<Event> eventList = new ArrayList(events);
     Collections.sort(eventList, (Event e1, Event e2) -> TimeRange.ORDER_BY_START.compare(e1.getWhen(), e2.getWhen()));
     
+    // Get the possible meeting times with and without the optional attendees.
     Collection<TimeRange> optionalTimes = getMeetingList(eventList, request, true);
     Collection<TimeRange> requiredTimes = getMeetingList(eventList, request, false);
 
@@ -38,6 +39,11 @@ public final class FindMeetingQuery {
     }
   }
 
+  /*
+  * @param events The list of existing, sorted events
+  * @param includeOptional Whether or not meeting times should include optional attendees
+  * @return A Collection of possible TimeRanges for the meeting
+  */
   private Collection<TimeRange> getMeetingList(List<Event> events, MeetingRequest request, boolean includeOptional) {
     Collection<TimeRange> availableTimes = new ArrayList<TimeRange>();
 
@@ -53,8 +59,8 @@ public final class FindMeetingQuery {
 
       if (includeOptional) {
         if (noRequiredMembers && noOptionalMembers) continue;
-      } else {
-        if (noRequiredMembers) continue;
+      } else if (noRequiredMembers) {
+        continue;
       }
 
       if (theoreticalStart < event.getWhen().start()) {
@@ -65,12 +71,10 @@ public final class FindMeetingQuery {
 
         // Move theoretical start pointer to after the event.
         theoreticalStart = event.getWhen().end();
-        continue;
 
         // If the theoretical start is in the middle of the event, move theoretical start to after the event.
       } else if (theoreticalStart < event.getWhen().end()) {
         theoreticalStart = event.getWhen().end();
-        continue;
       }
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -26,7 +26,7 @@ public final class FindMeetingQuery {
     List<Event> eventList = new ArrayList(events);
     Collections.sort(eventList, (Event e1, Event e2) -> TimeRange.ORDER_BY_START.compare(e1.getWhen(), e2.getWhen()));
     
-    // Get the possible meeting times with and without the optional attendees.
+    // Get the possible meeting times with the optional attendees.
     Collection<TimeRange> optionalTimes = getMeetingList(eventList, request, true);
 
     if (optionalTimes.size() > 0) {
@@ -38,11 +38,12 @@ public final class FindMeetingQuery {
     }
   }
 
-  /*
-  * @param events The list of existing, sorted events
-  * @param includeOptional Whether or not meeting times should include optional attendees
-  * @return A Collection of possible TimeRanges for the meeting
-  */
+  /**
+   * @param events The list of existing, sorted events
+   * @param request The meeting request, containing attendees and duration
+   * @param includeOptional Whether or not meeting times should include optional attendees
+   * @return A Collection of possible TimeRanges for the meeting
+   */
   private Collection<TimeRange> getMeetingList(List<Event> events, MeetingRequest request, boolean includeOptional) {
     Collection<TimeRange> availableTimes = new ArrayList<TimeRange>();
 
@@ -56,11 +57,7 @@ public final class FindMeetingQuery {
       boolean noRequiredMembers = Collections.disjoint(event.getAttendees(), request.getAttendees());
       boolean noOptionalMembers = Collections.disjoint(event.getAttendees(), request.getOptionalAttendees());
 
-      if (includeOptional) {
-        if (noRequiredMembers && noOptionalMembers) continue;
-      } else if (noRequiredMembers) {
-        continue;
-      }
+      if (noRequiredMembers && (noOptionalMembers || !includeOptional)) continue;
 
       if (theoreticalStart < event.getWhen().start()) {
         // If the meeting can happen before the event starts, add it.

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -92,8 +92,8 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -119,9 +119,9 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -147,8 +147,8 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -175,8 +175,8 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -201,8 +201,8 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -217,9 +217,9 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /* inclusive= */ true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -266,9 +266,9 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /* inclusive= */ true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
@@ -299,9 +299,9 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -327,8 +327,8 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
-            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /* inclusive= */ false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -339,11 +339,11 @@ public final class FindMeetingQueryTest {
     // include them in the meeting.
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /* inclusive= */ true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, /* inclusive= */ true),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -361,13 +361,13 @@ public final class FindMeetingQueryTest {
     // Only have two optional people with some gaps for meeting times.
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, false),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, /* inclusive= */ false),
             Arrays.asList(PERSON_B)),
-        new Event("Event 4", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 4", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /* inclusive= */ true),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
@@ -376,7 +376,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, false));
+        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, /* inclusive= */ false));
 
     Assert.assertEquals(expected, actual);
   }
@@ -386,13 +386,13 @@ public final class FindMeetingQueryTest {
     // Only have two optional people with no gaps for meeting times.
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, false),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, /* inclusive= */ false),
             Arrays.asList(PERSON_B)),
-        new Event("Event 4", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, false),
+        new Event("Event 4", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /* inclusive= */ false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
@@ -410,9 +410,9 @@ public final class FindMeetingQueryTest {
     // Have two optional people with overlapping events.
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0815AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0815AM, /* inclusive= */ false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0800AM, TIME_1000AM, false),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0800AM, TIME_1000AM, /* inclusive= */ false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
@@ -421,7 +421,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /* inclusive= */ true));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -359,7 +359,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, false),
             Arrays.asList(PERSON_B)),
-        new Event("Event 4", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, false),
+        new Event("Event 4", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Collections.emptyList(), DURATION_30_MINUTES);
@@ -368,7 +368,7 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, true));
+        Arrays.asList(TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, false));
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
Added logic for handling meetings with optional attendees. The getMeetingList method is given the sorted events and a boolean indicating whether to include optional attendees, then returns possible meeting times. The query method sorts the events, calls getMeetingList, and determines whether optional attendees can be included or not.